### PR TITLE
chore: enable GitHub Action with deploy to npm automation

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,68 @@
+name: NPM
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [14, 12, 10, 8]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Test
+        run: npm test
+
+  publish:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/v'))
+    name: Publish
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install Dependencies
+        run: npm install
+        run: npm install --global pkg-jq
+
+      - name: Set Publish Config
+        run: ./scripts/package-publish-config-tag.sh
+
+      - name: Build Dist
+        run: npm run build
+
+      - name: Check Branch
+        id: check-branch
+        run: |
+          if [[ ${{ github.ref }} =~ ^refs/heads/(master|v[0-9]+\.[0-9]+.*)$ ]]; then
+              echo ::set-output name=match::true
+          fi  # See: https://stackoverflow.com/a/58869470/1123955
+      - name: Is A Publish Branch
+        if: steps.check-branch.outputs.match == 'true'
+        run: |
+          NAME=$(npx pkg-jq -r .name)
+          VERSION=$(npx pkg-jq -r .version)
+          if npx version-exists "$NAME" "$VERSION"
+          then echo "$NAME@$VERSION exists on NPM, skipped."
+          else npm publish
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Is Not A Publish Branch
+        if: steps.check-branch.outputs.match != 'true'
+        run: echo 'Not A Publish Branch'

--- a/package.json
+++ b/package.json
@@ -88,5 +88,9 @@
       "eslint --ignore-pattern '!*'",
       "jest --findRelatedTests --passWithNoTests"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "next"
   }
 }

--- a/scripts/package-publish-config-tag.sh
+++ b/scripts/package-publish-config-tag.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+VERSION=$(npx pkg-jq -r .version)
+
+if npx --package @chatie/semver semver-is-prod "$VERSION"; then
+  npx pkg-jq -i '.publishConfig.tag="latest"'
+  echo "production release: publicConfig.tag set to latest."
+else
+  npx pkg-jq -i '.publishConfig.tag="next"'
+  echo 'development release: publicConfig.tag set to next.'
+fi
+


### PR DESCRIPTION
This is a simplified version of DevOps script that I used in many of my own projects like [Wechaty](https://github.com/wechaty/wechaty/blob/master/.github/workflows/npm.yml)

In order to enable the NPM to publish automation, we need to add npm token as a secret named `NPM_TOKEN` to our repo in `Settings > Secrets > Repository secrets`